### PR TITLE
feat: add `class` kwarg to `revealjs` and `html` shortcodes

### DIFF
--- a/_extensions/embedio/embedio.lua
+++ b/_extensions/embedio/embedio.lua
@@ -65,7 +65,7 @@ local function ensureSlideCSSPresent()
 end
 
 -- Define a function to generate HTML code for an iframe element
-local function iframe_helper(file_name, height, full_screen_link, template, type)
+local function iframe_helper(file_name, height, full_screen_link, class, template, type)
   -- Check if the file exists
   checkFile(file_name)
 
@@ -80,7 +80,7 @@ local function iframe_helper(file_name, height, full_screen_link, template, type
     -- Include full-screen link if specified
     (full_screen_link == "true" and string.format(template_full_screen, file_name, type) or ""), 
     -- Insert the iframe template with file name and height
-    string.format(template, file_name, height)
+    string.format(template, class, file_name, height)
   )
   
   -- Return the combined HTML as a pandoc RawBlock
@@ -96,16 +96,17 @@ local function html(args, kwargs, meta, raw_args)
   local file_name = pandoc.utils.stringify(args[1] or kwargs["file"])
   local height = getOption(kwargs, "height", "475px")
   local full_screen_link = getOption(kwargs, "full-screen-link", "true")
+  local class = getOption(kwargs, "class", "")
 
   -- Define the template for embedding HTML files
   local template_html = [[
-    <div>
+    <div%s>
       <iframe src=%q height=%q></iframe>
     </div>
   ]]
 
   -- Call the iframe_helper() function with the HTML template
-  return iframe_helper(file_name, height, full_screen_link, template_html, "webpage")
+  return iframe_helper(file_name, height, full_screen_link, class, template_html, "webpage")
 end
 
 -- Define the revealjs() function for embedding Reveal.js slides
@@ -120,16 +121,17 @@ local function revealjs(args, kwargs, meta, raw_args)
   local file_name = pandoc.utils.stringify(args[1] or kwargs["file"])
   local height = getOption(kwargs, "height", "475px")
   local full_screen_link = getOption(kwargs, "full-screen-link", "true")
+  local class = getOption(kwargs, "class", "")
 
   -- Define the template for embedding Reveal.js slides
   local template_revealjs = [[
-    <div>
+    <div%s>
       <iframe class="slide-deck" src=%q height=%q></iframe>
     </div>
   ]]
 
   -- Call the iframe_helper() function with the Reveal.js template
-  return iframe_helper(file_name, height, full_screen_link, template_revealjs, "slides")
+  return iframe_helper(file_name, height, full_screen_link, class, template_revealjs, "slides")
 end
 
 local function audio(args, kwargs, meta)

--- a/_extensions/embedio/embedio.lua
+++ b/_extensions/embedio/embedio.lua
@@ -69,6 +69,12 @@ local function iframe_helper(file_name, height, full_screen_link, class, templat
   -- Check if the file exists
   checkFile(file_name)
 
+  if isVariablePopulated(class) then
+    class = ' class="' .. class .. '"'
+  else
+    class = ""
+  end
+
   -- Define a template for displaying a full-screen link
   local template_full_screen = [[
     <p><a href=%q target="_blank">View %s in full screen</a></p>

--- a/docs/qembedio-embed-html.qmd
+++ b/docs/qembedio-embed-html.qmd
@@ -19,5 +19,6 @@ For example, the above shortcode embeds the `my-html-page.html` in `assets/` as:
 | `file`           | None          | Specifies the input file path for the HTML webpage.      |
 | `height`         | "475px"       | Specifies the height of the embedded webpage.            |
 | `full-screen-link`    | "true"        | Add a link to view the embedded webpage in a new full screen browser window.         |
+| `class`          | None          | Specifies the classes of the container wrapping the embedded webpage. |
 
 You may also omit specifying a `file` option. We'll automatically use the first parameter as the `file`

--- a/docs/qembedio-embed-revealjs.qmd
+++ b/docs/qembedio-embed-revealjs.qmd
@@ -5,12 +5,12 @@ title: "Embed RevealJS Slides"
 The `revealjs` short code generates an embedded `<iframe>` area for RevealJS HTML Slides. You can use it with:
 
 ```markdown
-{{{< revealjs file="assets/my-revealjs-slides.html" height="500px">}}}
+{{{< revealjs file="assets/my-revealjs-slides.html" height="500px" class="ratio ratio-16x9" >}}}
 ```
 
 For example, the above shortcode embeds the `my-revealjs-slides.html` in `assets/` as:
 
-{{< revealjs file="assets/my-revealjs-slides.html" height="500px" >}}
+{{< revealjs file="assets/my-revealjs-slides.html" height="500px" class="ratio ratio-16x9" >}}
 
 ## Options
 
@@ -19,5 +19,6 @@ For example, the above shortcode embeds the `my-revealjs-slides.html` in `assets
 | `file`           | None          | Specifies the input file path for the Reveal.js slides.  |
 | `height`         | "475px"       | Specifies the height of the embedded slide deck.         |
 | `full-screen-link`    | "true"        | Add a link to view the embedded slide deck in a new full screen browser window.         |
+| `class`          | None          | Specifies the classes of the container wrapping the embedded slide deck.          |
 
 You may also omit specifying a `file` option. We'll automatically use the first parameter as the `file`


### PR DESCRIPTION
Bootstrap has helpful [ratio classes](https://getbootstrap.com/docs/5.3/helpers/ratio/) that can be used in quarto pages to enforce a particular aspect ratio. This is super helpful for revealjs slides for example

```markdown
::: {.ratio .ratio-16x9}
{{< revealjs "slides.html" >}}
:::
```

The problem with the above approach is that the ratio class is applied too high in the HTML structure and the "View slides in full screen" link won't be visible.

This PR adds a `class` kwarg to `{{< revealjs >}}` and `{{< html >}}` that can be used to add classes to the `<div>` container wrapping the `<iframe>` element.

After this PR, the above example becomes

```markdown
{{< revealjs "slides.html" class="ratio ratio-16x9" >}}
```

and the view full screen slides link is displayed as expected.