### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/embedio/_schema.yml
+++ b/_extensions/embedio/_schema.yml
@@ -1,0 +1,107 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+shortcodes:
+  audio:
+    description: "Embed an audio file with an HTML audio player."
+    arguments:
+      - name: file
+        type: string
+        required: true
+        description: "Path to the audio file."
+        completion:
+          type: file
+    attributes:
+      caption:
+        type: string
+        description: "Caption text displayed below the audio player."
+      class:
+        type: string
+        description: "CSS class for the wrapping figure element."
+      download-link:
+        type: boolean
+        default: false
+        description: "Show a download link above the audio player."
+  pdf:
+    description: "Embed a PDF file inline."
+    arguments:
+      - name: file
+        type: string
+        required: true
+        description: "Path to the PDF file."
+        completion:
+          type: file
+    attributes:
+      height:
+        type: string
+        default: 600px
+        description: "Height of the embedded PDF viewer."
+        completion:
+          type: size
+      width:
+        type: string
+        default: 100%
+        description: "Width of the embedded PDF viewer."
+        completion:
+          type: size
+      download-link:
+        type: boolean
+        default: true
+        description: "Show a download link above the PDF."
+  revealjs:
+    description: "Embed a RevealJS slide deck in an iframe."
+    arguments:
+      - name: file
+        type: string
+        required: true
+        description: "Path to the RevealJS HTML file."
+        completion:
+          type: file
+    attributes:
+      height:
+        type: string
+        default: 475px
+        description: "Height of the iframe."
+        completion:
+          type: size
+      width:
+        type: string
+        default: 100%
+        description: "Width of the iframe."
+        completion:
+          type: size
+      full-screen-link:
+        type: boolean
+        default: true
+        description: "Show a link to view slides in full screen."
+      class:
+        type: string
+        description: "CSS class for the wrapping div element."
+  html:
+    description: "Embed an HTML page in an iframe."
+    arguments:
+      - name: file
+        type: string
+        required: true
+        description: "Path or URL of the HTML page."
+        completion:
+          type: file
+    attributes:
+      height:
+        type: string
+        default: 475px
+        description: "Height of the iframe."
+        completion:
+          type: size
+      width:
+        type: string
+        default: 100%
+        description: "Width of the iframe."
+        completion:
+          type: size
+      full-screen-link:
+        type: boolean
+        default: true
+        description: "Show a link to view the page in full screen."
+      class:
+        type: string
+        description: "CSS class for the wrapping div element."

--- a/_extensions/embedio/_snippets.json
+++ b/_extensions/embedio/_snippets.json
@@ -1,0 +1,30 @@
+{
+  "Embed Audio": {
+    "prefix": "embedio-audio",
+    "body": [
+      "{{< audio ${1:path/to/audio.mp3} >}}"
+    ],
+    "description": "Embed an audio file with an HTML audio player."
+  },
+  "Embed PDF": {
+    "prefix": "embedio-pdf",
+    "body": [
+      "{{< pdf ${1:path/to/file.pdf} >}}"
+    ],
+    "description": "Embed a PDF file inline."
+  },
+  "Embed RevealJS Slides": {
+    "prefix": "embedio-revealjs",
+    "body": [
+      "{{< revealjs ${1:path/to/slides.html} >}}"
+    ],
+    "description": "Embed a RevealJS slide deck in an iframe."
+  },
+  "Embed HTML": {
+    "prefix": "embedio-html",
+    "body": [
+      "{{< html ${1:path/to/page.html} >}}"
+    ],
+    "description": "Embed an HTML page in an iframe."
+  }
+}

--- a/_extensions/embedio/_snippets.json
+++ b/_extensions/embedio/_snippets.json
@@ -1,27 +1,27 @@
 {
   "Embed Audio": {
-    "prefix": "embedio-audio",
+    "prefix": "audio",
     "body": [
       "{{< audio ${1:path/to/audio.mp3} >}}"
     ],
     "description": "Embed an audio file with an HTML audio player."
   },
   "Embed PDF": {
-    "prefix": "embedio-pdf",
+    "prefix": "pdf",
     "body": [
       "{{< pdf ${1:path/to/file.pdf} >}}"
     ],
     "description": "Embed a PDF file inline."
   },
   "Embed RevealJS Slides": {
-    "prefix": "embedio-revealjs",
+    "prefix": "revealjs",
     "body": [
       "{{< revealjs ${1:path/to/slides.html} >}}"
     ],
     "description": "Embed a RevealJS slide deck in an iframe."
   },
   "Embed HTML": {
-    "prefix": "embedio-html",
+    "prefix": "html",
     "body": [
       "{{< html ${1:path/to/page.html} >}}"
     ],


### PR DESCRIPTION
## Summary

- Add `_schema.yml` declaring four shortcodes: `audio`, `pdf`, `revealjs`, and `html`, each with their arguments and attributes.
- Add `_snippets.json` with four snippets, one for each shortcode type.

## What is Quarto Wizard?

[Quarto Wizard](https://m.canouil.dev/quarto-wizard/dev/) is a VS Code extension that enhances the Quarto authoring experience with IDE tooling.
In its upcoming release, Quarto extensions will be able to contribute their own schema and snippets, which Quarto Wizard can use to provide autocompletion, validation, diagnostics, and snippet completion tailored to each extension.

Extensions opt in by shipping a `_schema.yml` file (declaring configurable options, shortcode parameters, element attributes, and CSS classes) and a `_snippets.json` file (VS Code-format snippets for common syntax patterns) alongside their `_extension.yml`.

- [Schema specification](https://m.canouil.dev/quarto-wizard/dev/reference/schema-specification.html)
- [Snippet specification](https://m.canouil.dev/quarto-wizard/dev/reference/snippet-specification.html)