### PR TITLE
Fix embedded source files not copied when rendering

### DIFF
--- a/_extensions/embedio/embedio.lua
+++ b/_extensions/embedio/embedio.lua
@@ -51,17 +51,20 @@ end
 
 -- Register a local file as a Quarto resource so it is copied to the output
 local function ensureResource(file_path)
-  if not file_path or isRemoteRef(file_path) then
+  if isVariableEmpty(file_path) or isRemoteRef(file_path) then
     return
   end
 
+  -- Strip query strings and fragments (e.g. audio.mp3#t=10)
+  local resource_path = file_path:match("^[^%?#]+") or file_path
+
   -- Resolve to an absolute path based on the input document's directory
   local abs_path
-  if file_path:find("^/") then
-    abs_path = file_path
+  if pandoc.path.is_absolute(resource_path) then
+    abs_path = resource_path
   else
     local doc_dir = pandoc.path.directory(quarto.doc.input_file)
-    abs_path = pandoc.path.normalize(pandoc.path.join({doc_dir, file_path}))
+    abs_path = pandoc.path.normalize(pandoc.path.join({doc_dir, resource_path}))
   end
 
   quarto.doc.add_resource(abs_path)

--- a/_extensions/embedio/embedio.lua
+++ b/_extensions/embedio/embedio.lua
@@ -42,6 +42,31 @@ local function checkFile(input)
   end
 end
 
+-- Check if a path is a remote reference (URL, data URI, or anchor)
+local function isRemoteRef(path)
+  return path:find("^%a+://") ~= nil or
+         path:find("^data:") ~= nil or
+         path:find("^#") ~= nil
+end
+
+-- Register a local file as a Quarto resource so it is copied to the output
+local function ensureResource(file_path)
+  if not file_path or isRemoteRef(file_path) then
+    return
+  end
+
+  -- Resolve to an absolute path based on the input document's directory
+  local abs_path
+  if file_path:find("^/") then
+    abs_path = file_path
+  else
+    local doc_dir = pandoc.path.directory(quarto.doc.input_file)
+    abs_path = pandoc.path.normalize(pandoc.path.join({doc_dir, file_path}))
+  end
+
+  quarto.doc.add_resource(abs_path)
+end
+
 -- Avoid duplicate class definitions
 local initializedSlideCSS = false
 
@@ -104,6 +129,9 @@ local function html(args, kwargs, meta, raw_args)
   local full_screen_link = getOption(kwargs, "full-screen-link", "true")
   local class = getOption(kwargs, "class", "")
 
+  -- Ensure file is copied to the output directory
+  ensureResource(file_name)
+
   -- Define the template for embedding HTML files
   local template_html = [[
     <div%s>
@@ -129,6 +157,9 @@ local function revealjs(args, kwargs, meta, raw_args)
   local width = getOption(kwargs, "width", "100%")
   local full_screen_link = getOption(kwargs, "full-screen-link", "true")
   local class = getOption(kwargs, "class", "")
+
+  -- Ensure file is copied to the output directory
+  ensureResource(file_name)
 
   -- Define the template for embedding Reveal.js slides
   local template_revealjs = [[
@@ -156,6 +187,9 @@ local function audio(args, kwargs, meta)
   -- Extracting input from args or kwargs
   local input = pandoc.utils.stringify(args[1] or kwargs.file)
   checkFile(input)
+
+  -- Ensure file is copied to the output directory
+  ensureResource(input)
 
   -- Add class attribute if provided
   if class then
@@ -208,7 +242,10 @@ local function pdf(args, kwargs, meta)
   -- Supported options for now
   local pdf_file_name = pandoc.utils.stringify(args[1] or kwargs["file"])
   checkFile(pdf_file_name)
-  
+
+  -- Ensure file is copied to the output directory
+  ensureResource(pdf_file_name)
+
   local height = getOption(kwargs, "height", "600px")
   local width = getOption(kwargs, "width", "100%")
   local download_link = getOption(kwargs, "download-link", "true")

--- a/docs/qembedio-embed-audio.qmd
+++ b/docs/qembedio-embed-audio.qmd
@@ -22,3 +22,7 @@ For example, the above shortcode embeds the `my-audio.mp3` in `assets/`  as:
 | `download-link`       | `"false"`     | Specifies whether to include a download link.         |
 
 You may also omit specifying a `file` option. We'll automatically use the first parameter as the `file`
+
+:::{.callout-tip}
+Having trouble with files not appearing in the rendered output? See the [troubleshooting section](qembedio-faq.qmd#im-encountering-issues-with-embedding-files.-what-should-i-do) of the FAQ.
+:::

--- a/docs/qembedio-embed-html.qmd
+++ b/docs/qembedio-embed-html.qmd
@@ -23,3 +23,7 @@ For example, the above shortcode embeds the `my-html-page.html` in `assets/` as:
 | `class`          | None          | Specifies the classes of the container wrapping the embedded webpage. |
 
 You may also omit specifying a `file` option. We'll automatically use the first parameter as the `file`
+
+:::{.callout-tip}
+Having trouble with files not appearing in the rendered output? See the [troubleshooting section](qembedio-faq.qmd#im-encountering-issues-with-embedding-files.-what-should-i-do) of the FAQ.
+:::

--- a/docs/qembedio-embed-pdf.qmd
+++ b/docs/qembedio-embed-pdf.qmd
@@ -22,3 +22,7 @@ For example, the above shortcode embeds the `my-pdf-file.pdf` in `assets/` as:
 | `download-link`    | "true"        | Add a link to download the embedded PDF in a new browser window.         |
 
 You may also omit specifying a `file` option. We'll automatically use the first parameter as the `file`
+
+:::{.callout-tip}
+Having trouble with files not appearing in the rendered output? See the [troubleshooting section](qembedio-faq.qmd#im-encountering-issues-with-embedding-files.-what-should-i-do) of the FAQ.
+:::

--- a/docs/qembedio-embed-revealjs.qmd
+++ b/docs/qembedio-embed-revealjs.qmd
@@ -23,3 +23,7 @@ For example, the above shortcode embeds the `my-revealjs-slides.html` in `assets
 | `class`          | None          | Specifies the classes of the container wrapping the embedded slide deck.          |
 
 You may also omit specifying a `file` option. We'll automatically use the first parameter as the `file`
+
+:::{.callout-tip}
+Having trouble with files not appearing in the rendered output? See the [troubleshooting section](qembedio-faq.qmd#im-encountering-issues-with-embedding-files.-what-should-i-do) of the FAQ.
+:::

--- a/docs/qembedio-faq.qmd
+++ b/docs/qembedio-faq.qmd
@@ -52,14 +52,16 @@ For more details, please see [Demo: RevealJS](qembedio-embed-revealjs.qmd).
 
 If you're experiencing difficulties with file embedding, first ensure that your Quarto project has the `embedio` shortcode extension installed by looking in the `_extensions` folder. 
 
-Next, make sure that the resource is specified in the `resources` key under the publishing format: 
+Starting with v0.0.3, the `embedio` shortcodes automatically register embedded files as Quarto resources, so they are copied to the output directory without any extra configuration.
+
+If you are using an older version of the extension (or need to include files that are _not_ referenced by a shortcode), you can manually declare them in the `resources` key under the publishing format:
 
 ```yaml
 ---
 title: Example resource inclusion
 format:
-  html: 
-    resources: 
+  html:
+    resources:
     - path/to/file.pdf
 ---
 ```

--- a/docs/qembedio-faq.qmd
+++ b/docs/qembedio-faq.qmd
@@ -63,6 +63,7 @@ format:
   html:
     resources:
     - path/to/file.pdf
+    - path/to/audio.mp3
 ---
 ```
 


### PR DESCRIPTION
Closes #15.

When using embedio shortcodes in a Quarto website, the referenced files (audio, PDF, HTML, revealjs) were not being copied to the rendered output directory. The player or iframe would render fine, but the actual media was missing. Users had to work around this by manually adding a `resources` key to their YAML header.

The shortcodes now call `quarto.doc.add_resource()` to automatically register each referenced file with Quarto's resource pipeline. An `ensureResource()` helper resolves the file path relative to the input document and skips remote URLs so only local files are handled. This is called in all four shortcode handlers.

The FAQ has also been updated to note that resource copying is now automatic, with the manual YAML approach kept as a fallback for older versions.